### PR TITLE
Add theme picker with light and dark modes

### DIFF
--- a/app/actions/theme.js
+++ b/app/actions/theme.js
@@ -1,0 +1,5 @@
+export const SET_THEME = 'SET_THEME';
+
+export function setTheme(theme) {
+  return { type: SET_THEME, theme };
+}

--- a/app/components/ThemePicker.css
+++ b/app/components/ThemePicker.css
@@ -1,0 +1,7 @@
+.themePicker {
+  margin-bottom: 0.5rem;
+}
+
+.themePicker select {
+  margin-left: 0.5rem;
+}

--- a/app/components/ThemePicker.js
+++ b/app/components/ThemePicker.js
@@ -1,0 +1,27 @@
+import React, { Component, PropTypes } from 'react';
+import style from './ThemePicker.css';
+
+export default class ThemePicker extends Component {
+  static propTypes = {
+    theme: PropTypes.string.isRequired,
+    setTheme: PropTypes.func.isRequired
+  };
+
+  onChange = (e) => {
+    this.props.setTheme(e.target.value);
+  };
+
+  render() {
+    return (
+      <div className={style.themePicker}>
+        <label>
+          Theme:
+          <select value={this.props.theme} onChange={this.onChange}>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+    );
+  }
+}

--- a/app/containers/App.css
+++ b/app/containers/App.css
@@ -1,38 +1,61 @@
 * {
   box-sizing: border-box;
   font-family: sans-serif;
-  color: #666;
+  color: var(--text-color);
 }
+
 a {
-  color: hsl(0, 0%, 20%);
+  color: var(--link-color);
   font-family: sans-serif;
 }
+
 body {
-  background-color: hsl(0, 0%, 95%);
   margin-right: 1rem;
   padding: 1rem;
   padding-top: 0;
   box-sizing: border-box;
   overflow: hidden;
 }
+
+body.light {
+  --text-color: #666;
+  --link-color: hsl(0, 0%, 20%);
+  --title-color: #091E42;
+  --list-bg-color: hsl(0, 0%, 30%);
+  background-color: hsl(0, 0%, 95%);
+}
+
+body.dark {
+  --text-color: #ddd;
+  --link-color: #8ab4f8;
+  --title-color: #fff;
+  --list-bg-color: #333;
+  background-color: #1e1e1e;
+}
+
 h1 {
   padding: .5rem 0;
   font-family: "helvetica";
   border-left: 4px solid #73A0E3;
   padding-left: .3rem;
-  color: #091E42;
+  color: var(--title-color);
 }
+
 .inlineButtons {
   display: flex;
   justify-content: space-between;
   width: 100%;
 }
+
 .listContainer {
-  background-color: hsl(0, 0%, 30%);
-    width: 100%;
-    height: 272px;
-    overflow: auto;
-    padding: 0;
-    margin: 0;
-    box-shadow: inset 1px 1px 1px 1px black;
+  background-color: var(--list-bg-color);
+  width: 100%;
+  height: 272px;
+  overflow: auto;
+  padding: 0;
+  margin: 0;
+  box-shadow: inset 1px 1px 1px 1px black;
+}
+
+.progress {
 }

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -6,8 +6,10 @@ import TicketListItem from '../components/TicketListItem';
 import ChangeTicket from '../components/ChangeTicket';
 import ProgressBar from '../components/ProgressBar';
 import FinishDay from '../components/FinishDay';
+import ThemePicker from '../components/ThemePicker';
 import * as TicketTypes from '../constants/TicketTypes';
 import * as TicketActions from '../actions/tickets';
+import * as ThemeActions from '../actions/theme';
 import style from './App.css';
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -17,16 +19,18 @@ import * as TempoAPI from '../utils/TempoAPI';
 
 @connect(
   state => ({
-    tickets: state.tickets
+    tickets: state.tickets,
+    theme: state.theme
   }),
   dispatch => ({
-    actions: bindActionCreators(TicketActions, dispatch)
+    actions: bindActionCreators({ ...TicketActions, ...ThemeActions }, dispatch)
   })
 )
 export default class App extends Component {
   static propTypes = {
     tickets: PropTypes.array.isRequired,
-    actions: PropTypes.object.isRequired
+    actions: PropTypes.object.isRequired,
+    theme: PropTypes.string.isRequired
   };
   constructor(props, context) {
     super(props, context);
@@ -40,6 +44,16 @@ export default class App extends Component {
     chrome.browserAction.setBadgeText({
       'text': '' 
     });
+  }
+  componentDidMount() {
+    document.body.classList.add(this.props.theme);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.theme !== this.props.theme) {
+      document.body.classList.remove(prevProps.theme);
+      document.body.classList.add(this.props.theme);
+    }
   }
   CreateTicketList = (actions) => {
     const { tickets } = this.props;
@@ -62,9 +76,10 @@ export default class App extends Component {
     });
   }
   render() {
-    const { tickets, actions } = this.props;
+    const { tickets, actions, theme } = this.props;
     return (
       <div className={style.progress}>
+        <ThemePicker theme={theme} setTheme={actions.setTheme} />
         <h1 onClick={this.debug}>TimeTracker</h1>
         <CurrentTicket ticket={this.props.tickets.find(function (element) { return element.completed == false})} incrementTime={actions.incrementTime} updateProgress={actions.updateProgress}/>
         <ProgressBar tickets={tickets} />

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
 import tickets from './tickets';
+import theme from './theme';
 
 export default combineReducers({
-  tickets
+  tickets,
+  theme
 });

--- a/app/reducers/theme.js
+++ b/app/reducers/theme.js
@@ -1,0 +1,12 @@
+import { SET_THEME } from '../actions/theme';
+
+const initialState = 'light';
+
+export default function theme(state = initialState, action) {
+  switch (action.type) {
+    case SET_THEME:
+      return action.theme;
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## Summary
- Add Redux theme state and actions for light/dark modes
- Introduce `ThemePicker` component and apply selected theme
- Style application via CSS variables for theming

## Testing
- `npm test` *(fails: TypeError Cannot set property navigator of #<Object> which has only a getter)*
- `npm run lint` *(fails: 21756 problems including 'Mixed spaces and tabs')*

------
https://chatgpt.com/codex/tasks/task_e_68999d04e5d08331af6164c504870550